### PR TITLE
Update alarm_control_panel.py

### DIFF
--- a/alarm_control_panel.py
+++ b/alarm_control_panel.py
@@ -18,11 +18,11 @@ from .router import FreeboxRouter
 
 
 from homeassistant.components.alarm_control_panel.const import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_CUSTOM_BYPASS,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
+    AlarmControlPanelEntityFeature.ARM_AWAY,
+    AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
+    AlarmControlPanelEntityFeature.ARM_HOME,
+    AlarmControlPanelEntityFeature.ARM_NIGHT,
+    AlarmControlPanelEntityFeature.TRIGGER,
 )
 
 from homeassistant.const import (


### PR DESCRIPTION
SUPPORT_ALARM_ARM_AWAY was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use AlarmControlPanelEntityFeature.ARM_AWAY instead, please report it to the author of the 'freebox_home' custom integration SUPPORT_ALARM_ARM_CUSTOM_BYPASS was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS instead, please report it to the author of the 'freebox_home' custom integration SUPPORT_ALARM_ARM_HOME was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use AlarmControlPanelEntityFeature.ARM_HOME instead, please report it to the author of the 'freebox_home' custom integration SUPPORT_ALARM_ARM_NIGHT was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use AlarmControlPanelEntityFeature.ARM_NIGHT instead, please report it to the author of the 'freebox_home' custom integration SUPPORT_ALARM_TRIGGER was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use AlarmControlPanelEntityFeature.TRIGGER instead, please report it to the author of the 'freebox_home' custom integration