### PR TITLE
Update config_flow.py

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, AbortFlow
+from homeassistant.data_entry_flow import FlowResultType.ABORT, AbortFlow
 
 from .const import DOMAIN  # pylint: disable=unused-import
 from .router import get_api


### PR DESCRIPTION
DEVICE_CLASS_SHUTTER was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use CoverDeviceClass.SHUTTER instead, please report it to the author of the 'freebox_home' custom integration