### PR TITLE
Update alarm_control_panel.py

### DIFF
--- a/alarm_control_panel.py
+++ b/alarm_control_panel.py
@@ -18,11 +18,11 @@ from .router import FreeboxRouter
 
 
 from homeassistant.components.alarm_control_panel.const import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_CUSTOM_BYPASS,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
+    AlarmControlPanelEntityFeature.AWAY,
+    AlarmControlPanelEntityFeature.BYPASS,
+    AlarmControlPanelEntityFeature.HOME,
+    AlarmControlPanelEntityFeature.NIGHT,
+    AlarmControlPanelEntityFeature.TRIGGER,
 )
 
 from homeassistant.const import (
@@ -31,10 +31,10 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMED_CUSTOM_BYPASS,
-    STATE_ALARM_PENDING,
-    STATE_ALARM_ARMING,
-    STATE_ALARM_DISARMING,
-    STATE_ALARM_TRIGGERED,
+    AlarmControlPanelState.PENDING,
+    AlarmControlPanelState.ARMING,
+    AlarmControlPanelState.DISARMING,
+    AlarmControlPanelState.TRIGGERED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -179,19 +179,19 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
 
     def set_state(self, state):
         if( state == "alarm1_arming"):
-            self._state = STATE_ALARM_ARMING
+            self._state = AlarmControlPanelState.ARMING
         elif( state == "alarm2_arming"):
-            self._state = STATE_ALARM_ARMING
+            self._state = AlarmControlPanelState.ARMING
         elif( state == "alarm1_armed"):
             self._state = STATE_ALARM_ARMED_AWAY
         elif( state == "alarm2_armed"):
             self._state = STATE_ALARM_ARMED_NIGHT
         elif( state == "alarm1_alert_timer"):
-            self._state = STATE_ALARM_TRIGGERED
+            self._state = AlarmControlPanelState.TRIGGERED
         elif( state == "alarm2_alert_timer"):
-            self._state = STATE_ALARM_TRIGGERED
+            self._state = AlarmControlPanelState.TRIGGERED
         elif( state == "alert"):
-            self._state = STATE_ALARM_TRIGGERED
+            self._state = AlarmControlPanelState.TRIGGERED
         else:
             self._state = STATE_ALARM_DISARMED
 


### PR DESCRIPTION
STATE_ALARM_PENDING was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.11. Use AlarmControlPanelState.PENDING instead, please report it to the author of the 'freebox_home' custom integration STATE_ALARM_ARMING was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.11. Use AlarmControlPanelState.ARMING instead, please report it to the author of the 'freebox_home' custom integration STATE_ALARM_DISARMING was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.11. Use AlarmControlPanelState.DISARMING instead, please report it to the author of the 'freebox_home' custom integration STATE_ALARM_TRIGGERED was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.11. Use AlarmControlPanelState.TRIGGERED instead, please report it to the author of the 'freebox_home' custom integration DEVICE_CLASS_BATTERY was used from freebox_home, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.BATTERY instead, please report it to the author of the 'freebox_home' custom integration