### PR TITLE
fix: corrections bugs critiques + modernisation Home Assistant APIs

### DIFF
--- a/custom_components/freebox_home/__init__.py
+++ b/custom_components/freebox_home/__init__.py
@@ -1,11 +1,8 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
-import asyncio
 import logging
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_DISCOVERY, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
-from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.core import HomeAssistant
 
 from freebox_api.exceptions import AuthorizationError, HttpRequestError
@@ -49,18 +46,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         router = hass.data[DOMAIN].pop(entry.unique_id)
-        # No need to remove the old file because I will clean when we recreate the entry again (and no need to get a new credential if it's working)
-        #await remove_config(hass, entry.data[CONF_HOST])
         await router.close()
 
     return unload_ok

--- a/custom_components/freebox_home/alarm_control_panel.py
+++ b/custom_components/freebox_home/alarm_control_panel.py
@@ -1,14 +1,10 @@
 """Support for Freebox alarm"""
 import logging
-import json
-import time
-import async_timeout
+import asyncio
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity
 from datetime import datetime, timedelta
 
@@ -38,7 +34,7 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
 
 class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
 
-    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, any]) -> None:
+    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, Any]) -> None:
         """Initialize an Alarm"""
         super().__init__(hass, router, node)
 
@@ -55,7 +51,6 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
         self._command_timeout3  = self.get_command_id(node['type']['endpoints'], "slot", "timeout3") # Durée de la sirène
         self._command_state     = self.get_command_id(node['type']['endpoints'], "signal", "state" )
 
-        #self.set_state("idle")
         self._freebox_alarm_state = "idle"
         self._unsub_watcher = None
         self._supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
@@ -73,13 +68,13 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
     async def async_alarm_disarm(self, code=None) -> None:
         """Send disarm command."""
         if( await self.set_home_endpoint_value(self._command_off, {"value": None})):
-            time.sleep(1)
+            await asyncio.sleep(1)
             self.schedule_update_ha_state(True)
 
     async def async_alarm_arm_away(self, code=None) -> None:
         """Send arm away command."""
         if( await self.set_home_endpoint_value(self._command_alarm1, {"value": None})):
-            time.sleep(1)
+            await asyncio.sleep(1)
             self._unsub_watcher = async_track_time_interval(self.hass, self.sync_update_during_arming, timedelta(seconds=1))
 
     async def async_alarm_arm_home(self, code=None) -> None:
@@ -88,7 +83,7 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
     async def async_alarm_arm_night(self, code=None) -> None:
         """Send arm night command."""
         if( await self.set_home_endpoint_value(self._command_alarm2, {"value": None})):
-            time.sleep(1)
+            await asyncio.sleep(1)
             self._unsub_watcher = async_track_time_interval(self.hass, self.sync_update_during_arming, timedelta(seconds=1))
 
     async def sync_update_during_arming(self, now: Optional[datetime] = None) -> None:
@@ -122,38 +117,18 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
 
         # Parse all endpoints values
         for endpoint in filter(lambda x:(x["ep_type"] == "signal"), node['show_endpoints']):
-            if( endpoint["name"] == "pin" ):
-                self._pin = endpoint["value"]
-            elif( endpoint["name"] == "sound" ):
+            if( endpoint["name"] == "sound" ):
                 self._sound = endpoint["value"]
             elif( endpoint["name"] == "volume" ):
                 self._high_volume = endpoint["value"]
             elif( endpoint["name"] == "timeout1" ):
                 self._timeout1 = endpoint["value"]
-            elif( endpoint["name"] == "timeout3" ):
+            elif( endpoint["name"] == "timeout2" ):
                 self._timeout2 = endpoint["value"]
             elif( endpoint["name"] == "timeout3" ):
                 self._timeout3 = endpoint["value"]
             elif( endpoint["name"] == "battery" ):
                 self._battery = endpoint["value"]
-
-#    def set_state(self, state):
-#        if( state == "alarm1_arming"):
-#            self._state = AlarmControlPanelState.ARMING
-#        elif( state == "alarm2_arming"):
-#            self._state = SAlarmControlPanelState.ARMING
-#        elif( state == "alarm1_armed"):
-#            self._state = AlarmControlPanelState.ARMED_AWAY
-#        elif( state == "alarm2_armed"):
-#            self._state = AlarmControlPanelState.ARMED_NIGHT
-#        elif( state == "alarm1_alert_timer"):
-#            self._state = AlarmControlPanelState.TRIGGERED
-#        elif( state == "alarm2_alert_timer"):
-#            self._state = AlarmControlPanelState.TRIGGERED
-#        elif( state == "alert"):
-#            self._state = AlarmControlPanelState.TRIGGERED
-#        else:
-#            self._state = AlarmControlPanelState.DISARMED
 
 
     @property
@@ -163,7 +138,7 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
         if( self._freebox_alarm_state == "alarm1_arming"):
             return AlarmControlPanelState.ARMING
         elif( self._freebox_alarm_state == "alarm2_arming"):
-            return SAlarmControlPanelState.ARMING
+            return AlarmControlPanelState.ARMING
         elif( self._freebox_alarm_state == "alarm1_armed"):
             return AlarmControlPanelState.ARMED_AWAY
         elif( self._freebox_alarm_state == "alarm2_armed"):
@@ -171,7 +146,7 @@ class FreeboxAlarm(FreeboxBaseClass, AlarmControlPanelEntity):
         elif( self._freebox_alarm_state == "alarm1_alert_timer"):
             return AlarmControlPanelState.TRIGGERED
         elif( self._freebox_alarm_state == "alarm2_alert_timer"):
-            returnAlarmControlPanelState.TRIGGERED
+            return AlarmControlPanelState.TRIGGERED
         elif( self._freebox_alarm_state == "alert"):
             return AlarmControlPanelState.TRIGGERED
         return AlarmControlPanelState.DISARMED

--- a/custom_components/freebox_home/base_class.py
+++ b/custom_components/freebox_home/base_class.py
@@ -1,16 +1,17 @@
 """Support for detectors covers."""
 import logging
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.device_registry import DeviceInfo
 from .const import DOMAIN, VALUE_NOT_SET, DUMMY
 from .router import FreeboxRouter
 
 _LOGGER = logging.getLogger(__name__)
 
 class FreeboxBaseClass(Entity):
-    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, any], sub_node = None) -> None:
+    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, Any], sub_node = None) -> None:
         _LOGGER.debug(node)
         self._hass = hass
         self._router = router
@@ -61,17 +62,17 @@ class FreeboxBaseClass(Entity):
         return self._available
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         if (self._is_device == False):
             return None
-        return {
-            "identifiers": {(DOMAIN, self._id)},
-            "name": self._device_name,
-            "manufacturer": self._manufacturer,
-            "model": self._model,
-            "sw_version": self._firmware,
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name=self._device_name,
+            manufacturer=self._manufacturer,
+            model=self._model,
+            sw_version=self._firmware,
+        )
 
     async def set_home_endpoint_value(self, command_id, value):
         #Dummy devices

--- a/custom_components/freebox_home/binary_sensor.py
+++ b/custom_components/freebox_home/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for motion detector, door opener detector and check for sensor plastic cover """
 import logging
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.helpers.event import async_track_time_interval
 from datetime import datetime, timedelta
@@ -42,17 +42,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 ''' Freebox motion detector sensor '''
 class FreeboxPir(FreeboxBaseClass, BinarySensorEntity):
 
-    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, any]) -> None:
+    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, Any]) -> None:
         """Initialize a Pir"""
         super().__init__(hass, router, node)
         self._command_trigger = self.get_command_id(node['type']['endpoints'], "signal", "trigger")
         self._detection = False
-        self._unsub_watcher = async_track_time_interval(self._hass, self.async_update_pir, timedelta(seconds=1))
+        self._unsub_watcher = async_track_time_interval(self._hass, self.async_update_pir, timedelta(seconds=5))
 
     async def async_update_pir(self, now: Optional[datetime] = None) -> None:
         detection = await self.get_home_endpoint_value(self._command_trigger)
-        if( self._detection == detection ):
-            self._detection = not detection
+        if self._detection != detection:
+            self._detection = detection
             self.async_write_ha_state()
 
     @property
@@ -86,46 +86,10 @@ class FreeboxDws(FreeboxPir):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return BinarySensorDeviceClass.DOOR
 
-'''
-class FreeboxDws(FreeboxBaseClass, BinarySensorEntity):
-    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, any]) -> None:
-        """Initialize a Dws"""
-        super().__init__(hass, router, node)
-        self._command_trigger = self.get_command_id(node['type']['endpoints'], "signal", "trigger")
-
-        self._detection = False
-        self._unsub_watcher = async_track_time_interval(self._hass, self.async_update_pir, timedelta(seconds=1))
-
-    async def async_update_pir(self, now: Optional[datetime] = None) -> None:
-        detection = await self.get_home_endpoint_value(self._command_trigger)
-        if( self._detection == detection ):
-            self._detection = not detection
-            self.async_write_ha_state()
-
-    @property
-    def is_on(self):
-        """Return true if the binary sensor is on."""
-        return self._detection
-
-    @property
-    def should_poll(self):
-        """Return True if entity has to be polled for state."""
-        return False
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_DOOR
-    
-    async def async_will_remove_from_hass(self):
-        """When entity will be removed from hass."""
-        self._unsub_watcher()
-        await super().async_will_remove_from_hass()
-'''
 
 ''' Freebox cover check for some sensors (motion detector, door opener detector...) '''
 class FreeboxSensorCover(FreeboxBaseClass, BinarySensorEntity):
-    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, any]) -> None:
+    def __init__(self, hass, router: FreeboxRouter, node: Dict[str, Any]) -> None:
         """Initialize a Cover for anothe Device"""
         # Get cover node
         cover_node = next(filter(lambda x: (x["name"]=="cover" and x["ep_type"]=="signal"), node['type']['endpoints']), None)

--- a/custom_components/freebox_home/camera.py
+++ b/custom_components/freebox_home/camera.py
@@ -1,15 +1,8 @@
 import logging
-import json
-import asyncio
-import aiohttp
-import async_timeout
-import collections
 
 from typing import Dict
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers import config_validation as cv, entity_platform, service
+from homeassistant.helpers import entity_platform
 
 from homeassistant.components.ffmpeg.camera import (
     FFmpegCamera,
@@ -19,27 +12,10 @@ from homeassistant.components.ffmpeg.camera import (
 )
 
 from homeassistant.components.camera import (
-    DEFAULT_CONTENT_TYPE,
-    PLATFORM_SCHEMA,
     CameraEntityFeature,
-    Camera,
 )
 from homeassistant.const import (
-    CONF_AUTHENTICATION,
     CONF_NAME,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_VERIFY_SSL,
-    HTTP_BASIC_AUTHENTICATION,
-    HTTP_DIGEST_AUTHENTICATION,
-)
-
-from homeassistant.components.generic.camera import (
-    CONF_CONTENT_TYPE,
-    CONF_LIMIT_REFETCH_TO_URL_CHANGE,
-    CONF_STILL_IMAGE_URL,
-    CONF_STREAM_SOURCE,
-    CONF_FRAMERATE
 )
 
 from .base_class import FreeboxBaseClass
@@ -48,37 +24,6 @@ from .router import FreeboxRouter
 
 
 _LOGGER = logging.getLogger(__name__)
-
-'''
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> None:
-    router = hass.data[DOMAIN][entry.unique_id]
-    tracked = set()
-
-    @callback
-    def update_router():
-        add_entities(hass, router, async_add_entities, tracked)
-
-    router.listeners.append(async_dispatcher_connect(hass, router.signal_device_new, update_router))
-    update_router()
-
-    platform = entity_platform.current_platform.get()
-    platform.async_register_entity_service("flip",{},"async_flip",)
-
-
-@callback
-def add_entities(hass, router, async_add_entities, tracked):
-    """Add new cover from the router."""
-    new_tracked = []
-    #_LOGGER.warning(router.nodes)
-    for nodeId, node in router.nodes.items():
-        if (node["category"]!="camera") or (node["id"] in tracked):
-            continue
-        new_tracked.append(FreeboxCamera(hass, router, node))
-        tracked.add(node["id"] )
-
-    if new_tracked:
-        async_add_entities(new_tracked, True)
-'''
 
 async def async_setup_entry(hass, entry, async_add_entities):
     router = hass.data[DOMAIN][entry.unique_id]
@@ -101,8 +46,21 @@ class FreeboxCamera(FreeboxBaseClass, FFmpegCamera):
 
         device_info = {CONF_NAME: node["label"].strip(),CONF_INPUT: node["props"]["Stream"],CONF_EXTRA_ARGUMENTS: DEFAULT_ARGUMENTS }
         FFmpegCamera.__init__(self, hass, device_info)
-        
-        #self._supported_features = CameraEntityFeature.STREAM
+
+        # Default attribute values — overridden by update_parameters()
+        self._motion_detection_enabled = False
+        self._activation_with_alarm = False
+        self._high_quality_video = False
+        self._motion_sensitivity = 0
+        self._motion_threshold = 0
+        self._flip = False
+        self._timestamp = None
+        self._volume_micro = 0
+        self._sound_detection = False
+        self._sound_trigger = False
+        self._rtsp = None
+        self._disk = None
+
         self.update_parameters(node)
         
         self._command_flip              = self.get_command_id(node['show_endpoints'], "slot", "flip")
@@ -113,9 +71,9 @@ class FreeboxCamera(FreeboxBaseClass, FFmpegCamera):
         await entity.set_home_endpoint_value(entity._command_flip, {"value": entity._flip})
 
     @property
-    def state_attributes(self):
+    def extra_state_attributes(self):
         """Return the camera state attributes."""
-        attr = super().state_attributes
+        attr = {}
         attr["motion_detection"]        = self.motion_detection_enabled
         attr["high_quality_video"]      = self._high_quality_video
         attr["flip_video"]              = self._flip

--- a/custom_components/freebox_home/config_flow.py
+++ b/custom_components/freebox_home/config_flow.py
@@ -16,7 +16,6 @@ _LOGGER = logging.getLogger(__name__)
 class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):
         """Initialize Freebox config flow."""
@@ -106,6 +105,7 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     # Ask for HOME permission
     async def async_step_permission(self, user_input=None):
         errors = {}
+        fbx = None
         try:
             fbx = await get_api(self.hass, self._host, self._port)
             await fbx.home.get_home_nodes()
@@ -122,8 +122,9 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception:
             _LOGGER.exception("Unknown error connecting with Freebox router at %s", self._host)
             errors["base"] = "unknown"
-        finally: 
-            await fbx.close()
+        finally:
+            if fbx is not None:
+                await fbx.close()
 
         return self.async_show_form(step_id="permission", errors=errors)
 

--- a/custom_components/freebox_home/cover.py
+++ b/custom_components/freebox_home/cover.py
@@ -1,9 +1,5 @@
 """Support for Freebox covers."""
 import logging
-import json
-from homeassistant.util import slugify
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.cover import CoverEntity, CoverDeviceClass
 from .const import DOMAIN, DUMMY, VALUE_NOT_SET
 from .base_class import FreeboxBaseClass
@@ -11,9 +7,7 @@ from homeassistant.helpers.entity_registry import async_get
 
 from homeassistant.const import (
     STATE_CLOSED,
-    STATE_CLOSING,
     STATE_OPEN,
-    STATE_OPENING,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -162,8 +156,9 @@ class FreeboxShutter(FreeboxBaseClass,CoverEntity):
             return True
         return False
 
-    async def async_set_cover_position(self, position, **kwargs):
+    async def async_set_cover_position(self, **kwargs):
         """Set cover position."""
+        position = kwargs.get("position")
         await self.set_home_endpoint_value(self._command_position, {"value": self.get_corrected_state(position)})
         self._current_state = position
 

--- a/custom_components/freebox_home/manifest.json
+++ b/custom_components/freebox_home/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "freebox_home",
-  "name": "Freebox Home",
+  "name": "Freebox Home Fork Sté",
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@gvigroux"],
   "config_flow": true,

--- a/custom_components/freebox_home/router.py
+++ b/custom_components/freebox_home/router.py
@@ -116,5 +116,12 @@ async def get_api(hass, host: str, port, retry = 0):
 async def remove_config(hass, host: str):
     freebox_path = Store(hass, STORAGE_VERSION, STORAGE_KEY).path
     token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
-    os.remove(token_file)
+    try:
+        resolved = token_file.resolve()
+        if not str(resolved).startswith(str(Path(freebox_path).resolve())):
+            _LOGGER.error("Invalid token file path, aborting removal: %s", token_file)
+            return
+        os.remove(token_file)
+    except FileNotFoundError:
+        _LOGGER.warning("Token file not found, skipping removal: %s", token_file)
 

--- a/custom_components/freebox_home/sensor.py
+++ b/custom_components/freebox_home/sensor.py
@@ -1,5 +1,5 @@
 from homeassistant.const import PERCENTAGE
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from .base_class import FreeboxBaseClass
 from .const import DOMAIN
 
@@ -15,7 +15,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(entities, True)
 
 
-class FreeboxBatterySensor(FreeboxBaseClass):
+class FreeboxBatterySensor(FreeboxBaseClass, SensorEntity):
 
     def __init__(self, hass, router, node, sub_node) -> None:
         """Initialize a Pir"""
@@ -27,11 +27,11 @@ class FreeboxBatterySensor(FreeboxBaseClass):
         return SensorDeviceClass.BATTERY
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the current state of the device."""
         return self.get_node_value(self._router.nodes[self._id]["show_endpoints"],"signal","battery")
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit_of_measurement of the device."""
         return PERCENTAGE

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,202 @@
+# Installation — Freebox Home pour Home Assistant
+
+Intégration des équipements **Freebox Delta** (alarme, volets, caméras, capteurs) dans Home Assistant.
+
+> **Compatibilité** : Freebox Delta uniquement (modèle avec le pack Home)
+
+---
+
+## Prérequis
+
+- Home Assistant **2023.1 ou supérieur**
+- Une **Freebox Delta** avec le pack Home activé
+- [HACS](https://hacs.xyz) installé dans Home Assistant *(méthode recommandée)*
+
+---
+
+## Méthode 1 — Via HACS (recommandée)
+
+### Étape 1 — Ajouter le dépôt personnalisé
+
+1. Dans Home Assistant, aller dans **HACS** → **Intégrations**
+2. Cliquer sur les **3 points** en haut à droite → **Dépôts personnalisés**
+3. Renseigner :
+   - **URL** : `https://github.com/absolusteph-corsica/freebox_home`
+   - **Catégorie** : `Intégration`
+4. Cliquer sur **Ajouter**
+
+### Étape 2 — Installer l'intégration
+
+1. Chercher **Freebox Home** dans la liste des intégrations HACS
+2. Cliquer sur **Télécharger**
+3. Confirmer le téléchargement
+
+### Étape 3 — Redémarrer Home Assistant
+
+**Paramètres** → **Système** → **Redémarrer**
+
+### Étape 4 — Configurer l'intégration
+
+Voir la section [Configuration](#configuration) ci-dessous.
+
+---
+
+## Méthode 2 — Installation manuelle
+
+### Étape 1 — Télécharger les fichiers
+
+```bash
+cd /config/custom_components
+git clone https://github.com/absolusteph-corsica/freebox_home tmp_fbx
+cp -r tmp_fbx/custom_components/freebox_home ./freebox_home
+rm -rf tmp_fbx
+```
+
+Ou télécharger le ZIP depuis la [page des releases](https://github.com/absolusteph-corsica/freebox_home/releases) et extraire le dossier `custom_components/freebox_home` dans `/config/custom_components/`.
+
+### Étape 2 — Vérifier la structure
+
+```
+config/
+└── custom_components/
+    └── freebox_home/
+        ├── __init__.py
+        ├── alarm_control_panel.py
+        ├── binary_sensor.py
+        ├── camera.py
+        ├── config_flow.py
+        ├── const.py
+        ├── cover.py
+        ├── manifest.json
+        ├── router.py
+        ├── sensor.py
+        ├── services.yaml
+        ├── switch.py
+        └── translations/
+            ├── en.json
+            └── fr.json
+```
+
+### Étape 3 — Redémarrer Home Assistant
+
+**Paramètres** → **Système** → **Redémarrer**
+
+### Étape 4 — Configurer l'intégration
+
+Voir la section [Configuration](#configuration) ci-dessous.
+
+---
+
+## Configuration
+
+### Étape 1 — Ajouter l'intégration
+
+1. **Paramètres** → **Appareils et services** → **Ajouter une intégration**
+2. Rechercher **Freebox Home**
+3. Renseigner :
+   - **Hôte** : l'adresse de votre Freebox (ex: `mafreebox.freebox.fr` ou l'IP locale)
+   - **Port** : le port HTTPS de l'API (ex: `443` ou le port indiqué sur `http://mafreebox.freebox.fr/api_version`)
+
+> Pour obtenir les valeurs exactes, ouvrir `http://mafreebox.freebox.fr/api_version` depuis votre réseau local et noter `api_domain` et `https_port`.
+
+### Étape 2 — Autoriser l'application sur la Freebox
+
+Lorsque la page vous le demande :
+
+1. **Appuyer sur la flèche droite** du panneau de la Freebox (bouton physique)
+2. Revenir dans Home Assistant et cliquer **Soumettre**
+
+### Étape 3 — Accorder les permissions Home
+
+1. Ouvrir [http://mafreebox.freebox.fr/#Fbx.os.app.settings.Accounts](http://mafreebox.freebox.fr/#Fbx.os.app.settings.Accounts)
+2. Trouver l'entrée **Home Assistant**
+3. Activer la permission : **Gestion de l'alarme et maison connectée**
+4. Revenir dans HA et cliquer **Soumettre**
+
+---
+
+## Découverte automatique (Zeroconf)
+
+Si votre Freebox Delta est sur le même réseau local que HA, l'intégration peut être découverte automatiquement via **Zeroconf**. Une notification apparaîtra dans HA pour proposer la configuration.
+
+> Seule la **Freebox Delta** est supportée — les autres modèles (Freebox Pop, Révolution, etc.) seront ignorés.
+
+---
+
+## Entités créées
+
+Selon les équipements associés à votre Freebox Delta :
+
+| Catégorie | Type d'entité HA | Description |
+|-----------|-----------------|-------------|
+| Alarme | `alarm_control_panel` | Centrale d'alarme Freebox |
+| Volet RTS/IO | `cover` | Volets roulants Somfy |
+| Volet basic | `cover` | Volets sans retour de position |
+| Caméra | `camera` | Caméra Freebox |
+| PIR | `binary_sensor` | Capteur de mouvement |
+| DWS | `binary_sensor` | Capteur d'ouverture de porte |
+| Batterie | `sensor` | Niveau de batterie (%) |
+| Couvercle capteur | `binary_sensor` | Détection d'ouverture du boîtier |
+| Inversion volet | `switch` | Inverse le sens de commande d'un volet |
+
+---
+
+## Mise à jour
+
+### Via HACS
+1. **HACS** → **Intégrations** → **Freebox Home**
+2. Si une mise à jour est disponible, cliquer **Mettre à jour**
+3. Redémarrer HA
+
+### Manuellement
+```bash
+cd /config/custom_components
+git clone https://github.com/absolusteph-corsica/freebox_home tmp_fbx
+cp -r tmp_fbx/custom_components/freebox_home ./freebox_home
+rm -rf tmp_fbx
+# Puis redémarrer HA
+```
+
+---
+
+## Désinstallation
+
+### Via HACS
+1. **HACS** → **Intégrations** → **Freebox Home** → **Supprimer**
+2. **Paramètres** → **Appareils et services** → **Freebox Home** → **Supprimer l'intégration**
+3. Redémarrer HA
+
+### Manuellement
+```bash
+rm -rf /config/custom_components/freebox_home
+```
+Puis supprimer l'intégration dans HA et redémarrer.
+
+---
+
+## Dépannage
+
+### L'intégration ne trouve pas la Freebox
+- Vérifier que l'hôte et le port sont corrects via `http://mafreebox.freebox.fr/api_version`
+- S'assurer que HACS et HA sont sur le **même réseau** que la Freebox
+
+### Erreur "Authorization" lors de la configuration
+- La demande d'autorisation a expiré — recommencer la configuration
+- Le fichier de token sera automatiquement réinitialisé
+
+### Erreur "Insufficient Permissions" après configuration
+- Retourner sur [la page des comptes Freebox](http://mafreebox.freebox.fr/#Fbx.os.app.settings.Accounts)
+- Vérifier que la permission **Gestion de l'alarme et maison connectée** est bien activée
+
+### Aucune entité créée après configuration
+- Vérifier que des équipements Home sont bien associés à votre Freebox Delta
+- Consulter les logs HA : **Paramètres** → **Système** → **Journaux** et filtrer sur `freebox_home`
+
+---
+
+## Liens utiles
+
+- [Dépôt GitHub](https://github.com/absolusteph-corsica/freebox_home)
+- [Signaler un bug](https://github.com/absolusteph-corsica/freebox_home/issues)
+- [API Freebox](http://mafreebox.freebox.fr/api_version)
+- [Paramètres des comptes Freebox](http://mafreebox.freebox.fr/#Fbx.os.app.settings.Accounts)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,336 @@
+# Plan d'implémentation — Corrections et améliorations Freebox Home
+
+> Issu de l'audit complet du code réalisé le 06/04/2026.
+
+## Objectif
+
+Corriger les bugs critiques (crashs, logique inversée), moderniser l'intégration pour les APIs Home Assistant actuelles, supprimer le code mort, et améliorer la sécurité et la maintenabilité.
+
+Le plan est découpé en **5 phases** indépendamment vérifiables, ordonnées par priorité.
+
+## Dépendances entre les phases
+
+```
+Phase 1 (P0 — Bugs critiques)
+    │
+    ▼
+Phase 2 (P1 — Bugs importants)
+    │
+    ├──► Phase 3 (P2 — Modernisation HA)   ─┐
+    ├──► Phase 4 (P2-P3 — Nettoyage)        ├── parallélisables
+    └──► Phase 5 (P2-P3 — Sécurité)        ─┘
+```
+
+---
+
+## Phase 1 — Bugs critiques (P0)
+
+### 1.1 Corriger les erreurs de syntaxe dans `alarm_state`
+
+- **Fichier** : `alarm_control_panel.py`, propriété `alarm_state`
+- **Bug A (ligne ~157)** : `SAlarmControlPanelState.ARMING` → typo, `S` en trop → `NameError`
+- **Bug B (ligne ~163)** : `returnAlarmControlPanelState.TRIGGERED` → espace manquant → `NameError`
+- **Correction** :
+  ```python
+  # Bug A
+  - return SAlarmControlPanelState.ARMING
+  + return AlarmControlPanelState.ARMING
+
+  # Bug B
+  - returnAlarmControlPanelState.TRIGGERED
+  + return AlarmControlPanelState.TRIGGERED
+  ```
+
+### 1.2 Corriger la logique inversée du capteur PIR
+
+- **Fichier** : `binary_sensor.py`, méthode `FreeboxPir.async_update_pir()`
+- **Bug** : La condition `==` devrait être `!=`, et la valeur assignée est inversée
+- **Impact** : Affecte aussi `FreeboxDws` (héritage)
+- **Correction** :
+  ```python
+  - if( self._detection == detection ):
+  -     self._detection = not detection
+  + if self._detection != detection:
+  +     self._detection = detection
+  ```
+
+### 1.3 Protéger `fbx.close()` dans le config flow
+
+- **Fichier** : `config_flow.py`, méthode `async_step_permission()`
+- **Bug** : Si `get_api()` lève une exception, `fbx` n'est pas défini mais le `finally` tente `await fbx.close()` → `UnboundLocalError`
+- **Correction** :
+  ```python
+  + fbx = None
+    try:
+        fbx = await get_api(self.hass, self._host, self._port)
+        ...
+    finally:
+  -     await fbx.close()
+  +     if fbx is not None:
+  +         await fbx.close()
+  ```
+
+### ✅ Vérification Phase 1
+
+- [ ] Charger l'intégration → aucune `NameError` / `UnboundLocalError` dans les logs
+- [ ] Tester le changement d'état de l'alarme vers `alarm2_arming` et `alarm2_alert_timer`
+- [ ] Vérifier que les capteurs PIR et DWS reflètent correctement l'état détecté/non-détecté
+- [ ] Simuler une erreur de connexion dans le config flow → le `finally` ne crashe pas
+
+---
+
+## Phase 2 — Bugs importants (P1)
+
+> Dépend de la validation de la Phase 1.
+
+### 2.1 Remplacer `time.sleep()` par `asyncio.sleep()`
+
+- **Fichier** : `alarm_control_panel.py`
+- **Méthodes** : `async_alarm_disarm()`, `async_alarm_arm_away()`, `async_alarm_arm_night()`
+- **Problème** : `time.sleep(1)` bloque toute la boucle asyncio de HA pendant 1 seconde
+- **Correction** :
+  ```python
+  + import asyncio
+  - import time
+
+  - time.sleep(1)
+  + await asyncio.sleep(1)
+  ```
+
+### 2.2 Corriger le doublon timeout3/timeout2
+
+- **Fichier** : `alarm_control_panel.py`, méthode `update_parameters()`
+- **Bug** : `timeout2` n'est jamais lu, `timeout3` est testé deux fois (2ème branche = code mort)
+- **Correction** :
+  ```python
+  - elif( endpoint["name"] == "timeout3" ):
+  -     self._timeout2 = endpoint["value"]
+  + elif( endpoint["name"] == "timeout2" ):
+  +     self._timeout2 = endpoint["value"]
+  ```
+
+### 2.3 Initialiser tous les attributs dans `FreeboxCamera.__init__`
+
+- **Fichier** : `camera.py`, méthode `FreeboxCamera.__init__()`
+- **Problème** : Les attributs (`_flip`, `_motion_threshold`, etc.) ne sont jamais initialisés. Si `update_parameters()` ne trouve pas l'endpoint correspondant, les `@property` lèvent un `AttributeError`.
+- **Correction** : Ajouter avant l'appel à `update_parameters()` :
+  ```python
+  self._motion_detection_enabled = False
+  self._activation_with_alarm = False
+  self._high_quality_video = False
+  self._motion_sensitivity = 0
+  self._motion_threshold = 0
+  self._flip = False
+  self._timestamp = None
+  self._volume_micro = 0
+  self._sound_detection = False
+  self._sound_trigger = False
+  self._rtsp = None
+  self._disk = None
+  ```
+
+### 2.4 Protéger `os.remove()` dans `remove_config`
+
+- **Fichier** : `router.py`, fonction `remove_config()`
+- **Bug** : `os.remove(token_file)` lève `FileNotFoundError` si le fichier n'existe pas
+- **Correction** :
+  ```python
+  - os.remove(token_file)
+  + try:
+  +     os.remove(token_file)
+  + except FileNotFoundError:
+  +     _LOGGER.warning("Token file not found: %s", token_file)
+  ```
+
+### ✅ Vérification Phase 2
+
+- [ ] L'armement/désarmement de l'alarme ne bloque plus l'interface
+- [ ] Dans les logs : `timeout1`, `timeout2`, `timeout3` sont correctement lus
+- [ ] Accéder aux attributs d'une caméra juste après sa création (avant le premier update) → aucun `AttributeError`
+- [ ] `remove_config` avec fichier absent → pas de crash
+
+---
+
+## Phase 3 — Modernisation Home Assistant (P2)
+
+> Parallélisable avec les Phases 4 et 5.
+
+### 3.1 Migrer `FreeboxBatterySensor` vers `SensorEntity`
+
+- **Fichier** : `sensor.py`
+- Importer `SensorEntity` depuis `homeassistant.components.sensor`
+- Changer l'héritage : `class FreeboxBatterySensor(FreeboxBaseClass, SensorEntity)`
+- Remplacer les propriétés :
+  - `state` → `native_value`
+  - `unit_of_measurement` → `native_unit_of_measurement`
+
+### 3.2 Migrer `device_info` vers `DeviceInfo`
+
+- **Fichier** : `base_class.py`
+- Importer `DeviceInfo` depuis `homeassistant.helpers.device_registry`
+- Modifier la property `device_info` pour retourner un objet `DeviceInfo(...)` au lieu d'un dict brut :
+  ```python
+  return DeviceInfo(
+      identifiers={(DOMAIN, self._id)},
+      name=self._device_name,
+      manufacturer=self._manufacturer,
+      model=self._model,
+      sw_version=self._firmware,
+  )
+  ```
+
+### 3.3 Migrer `state_attributes` → `extra_state_attributes`
+
+- **Fichier** : `camera.py`
+- Renommer la property `state_attributes` en `extra_state_attributes`
+- Ne pas appeler `super().state_attributes` — retourner un dict indépendant
+
+### 3.4 Moderniser `async_unload_entry`
+
+- **Fichier** : `__init__.py`
+- Remplacer le pattern `asyncio.gather` par :
+  ```python
+  unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+  ```
+- Supprimer `import asyncio`
+
+### 3.5 Corriger la signature de `async_set_cover_position`
+
+- **Fichier** : `cover.py`, classe `FreeboxShutter`
+- Changer la signature :
+  ```python
+  - async def async_set_cover_position(self, position, **kwargs):
+  + async def async_set_cover_position(self, **kwargs):
+  +     position = kwargs.get("position")
+  ```
+
+### 3.6 Supprimer `CONNECTION_CLASS` deprecated
+
+- **Fichier** : `config_flow.py`
+- Supprimer la ligne `CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL`
+
+### ✅ Vérification Phase 3
+
+- [ ] Capteur batterie affiché correctement avec unité %
+- [ ] Devices dans le registre avec manufacturer, model, sw_version corrects
+- [ ] Attributs supplémentaires de la caméra visibles dans les détails de l'entité
+- [ ] Unload/reload de l'intégration sans erreur
+- [ ] Position volet via slider HA fonctionnelle
+
+---
+
+## Phase 4 — Nettoyage du code (P2-P3)
+
+> Parallélisable avec les Phases 3 et 5.
+
+### 4.1 Supprimer le code mort
+
+| Fichier | Code à supprimer |
+|---------|-----------------|
+| `alarm_control_panel.py` | Bloc commenté `set_state()` (~lignes 139-155) |
+| `camera.py` | Ancien `async_setup_entry` + `add_entities` commentés (~lignes 55-80) |
+| `binary_sensor.py` | Classe `FreeboxDws` commentée (~lignes 93-130) |
+| `cover.py` | Commentaires de debug liés à `DUMMY` |
+
+### 4.2 Supprimer les imports inutilisés
+
+| Fichier | Imports à supprimer |
+|---------|-------------------|
+| `camera.py` | `json`, `aiohttp`, `async_timeout`, `collections`, `asyncio`, `callback`, `async_dispatcher_connect`, constantes HTTP/auth non utilisées (`CONF_AUTHENTICATION`, `CONF_PASSWORD`, `CONF_USERNAME`, `CONF_VERIFY_SSL`, `HTTP_BASIC_AUTHENTICATION`, `HTTP_DIGEST_AUTHENTICATION`), constantes generic non utilisées (`CONF_CONTENT_TYPE`, `CONF_LIMIT_REFETCH_TO_URL_CHANGE`, `CONF_STILL_IMAGE_URL`, `CONF_FRAMERATE`) |
+| `__init__.py` | `vol`, `discovery`, `asyncio` (après Phase 3.4) |
+| `cover.py` | `json`, `callback`, `async_dispatcher_connect`, `STATE_CLOSING`, `STATE_OPENING` |
+| `alarm_control_panel.py` | `json`, `async_timeout`, `time` (après Phase 2.1) |
+
+### 4.3 Corriger les type hints
+
+- Partout : `Dict[str, any]` → `Dict[str, Any]` (majuscule sur `Any`)
+- Fichiers impactés : `base_class.py`, `alarm_control_panel.py`, `binary_sensor.py`
+
+### 4.4 Nettoyer le style (optionnel)
+
+- Supprimer les parenthèses inutiles dans les `if(...)` → `if ...:`
+- Supprimer les points-virgules en fin de ligne
+- Harmoniser les espaces autour des `=`
+- Peut être fait via un formatter (`ruff format`, `black`)
+
+### ✅ Vérification Phase 4
+
+- [ ] `ruff check` ou `pylint` sans warning d'import inutilisé
+- [ ] L'intégration charge toujours correctement après le nettoyage
+- [ ] Aucune régression fonctionnelle
+
+---
+
+## Phase 5 — Sécurité et robustesse (P2-P3)
+
+> Parallélisable avec les Phases 3 et 4.
+
+### 5.1 Ne pas stocker/exposer le code PIN
+
+- **Fichier** : `alarm_control_panel.py`
+- Supprimer `self._pin = endpoint["value"]` ou masquer la valeur (`****`) dans tout log ou attribut exposé
+- Le PIN ne doit jamais apparaître dans les logs, même en mode debug
+
+### 5.2 Réduire la fréquence de polling des capteurs PIR/DWS
+
+- **Fichier** : `binary_sensor.py`
+- `FreeboxPir` : `timedelta(seconds=1)` → `timedelta(seconds=5)`
+- `FreeboxDws` : hérite la même modification
+- `FreeboxSensorCover` : conserver `timedelta(seconds=3)` (acceptable)
+- **Impact** : Réduit significativement la charge CPU et réseau (~5× moins de requêtes API)
+
+### 5.3 Valider le path dans `remove_config`
+
+- **Fichier** : `router.py`
+- Vérifier que `token_file` est bien un enfant de `freebox_path` avant de le supprimer :
+  ```python
+  token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
+  if not token_file.resolve().is_relative_to(Path(freebox_path).resolve()):
+      _LOGGER.error("Invalid token file path: %s", token_file)
+      return
+  ```
+
+### 5.4 Envisager la migration du stockage d'inversion (optionnel)
+
+- **Fichier** : `switch.py`
+- Remplacer `path.write_text('1')` / `path.read_text()` par `Store` de HA pour un stockage JSON plus robuste
+- OU conserver le mécanisme actuel mais ajouter un `try/except` autour de l'écriture
+
+### ✅ Vérification Phase 5
+
+- [ ] Le PIN n'apparaît nulle part dans les logs ni les attributs d'entité
+- [ ] Charge CPU/réseau réduite (observable dans les logs avec le niveau DEBUG)
+- [ ] Tenter `remove_config` avec un host contenant des caractères spéciaux → pas de suppression inattendue
+
+
+---
+
+## Récapitulatif des fichiers impactés
+
+| Fichier | Phases |
+|---------|--------|
+| `alarm_control_panel.py` | 1.1, 2.1, 2.2, 4.1, 4.2, 5.1 |
+| `binary_sensor.py` | 1.2, 4.1, 4.3, 5.2 |
+| `config_flow.py` | 1.3, 3.6 |
+| `camera.py` | 2.3, 3.3, 4.1, 4.2 |
+| `router.py` | 2.4, 5.3 |
+| `__init__.py` | 3.4, 4.2 |
+| `base_class.py` | 3.2, 4.3 |
+| `sensor.py` | 3.1 |
+| `cover.py` | 3.5, 4.2, 4.3 |
+| `switch.py` | 5.4 |
+
+## Décisions architecturales
+
+- Les phases 1 et 2 sont **séquentielles** (la 2 dépend de la validation de la 1)
+- Les phases 3, 4 et 5 sont **parallélisables** entre elles
+- Le code `DUMMY` (`const.py` + `router.py` JSON hardcodé) est conservé mais marqué pour suppression future
+- **Aucun nouveau fichier de code** n'est créé — uniquement des modifications de fichiers existants
+
+## Hors périmètre
+
+Ces éléments sont recommandés mais constituent des chantiers séparés :
+
+- **Tests unitaires** : Aucune couverture de test actuellement. À traiter dans un projet dédié.
+- **Migration vers `CoordinatorEntity`** : Pattern moderne HA pour centraliser le polling. Changement architectural majeur.
+- **Refactoring du polling vers push/webhook** : Remplacement de l'intervalle de polling par des notifications push de la Freebox (si l'API le supporte).


### PR DESCRIPTION
## Corrections apportées

### Bugs critiques 
- `alarm_control_panel`: corrige NameError `SAlarmControlPanelState` et `returnAlarmControlPanelState`
- `alarm_control_panel`: corrige doublon timeout3/timeout3 → timeout2/timeout3
- `binary_sensor`: corrige logique PIR inversée (état toggé au lieu de copié)
- `config_flow`: protège `fbx.close()` dans finally (UnboundLocalError si get_api échoue)

### Bugs importants 
- `alarm_control_panel`: remplace `time.sleep()` par `await asyncio.sleep()` (bloquait la boucle asyncio)
- `camera`: initialise les 12 attributs dans `__init__` (évitait AttributeError avant le premier update)
- `router`: protège `os.remove()` avec try/except FileNotFoundError

### Modernisation Home Assistant 
- `sensor`: migre vers `SensorEntity`, `native_value`, `native_unit_of_measurement`
- `base_class`: `device_info` retourne `DeviceInfo()` au lieu d'un dict brut
- `camera`: `state_attributes` → `extra_state_attributes`
- `__init__`: utilise `async_unload_platforms()` au lieu de `asyncio.gather`
- `cover`: corrige signature `async_set_cover_position(**kwargs)`
- `config_flow`: supprime `CONNECTION_CLASS` deprecated

### Sécurité
- Suppression du stockage du code PIN de l'alarme
- Réduction du polling PIR/DWS de 1s à 5s
- Validation du path dans `remove_config` (protection path traversal)

### Nettoyage
- Suppression du code mort commenté
- Suppression des imports inutilisés
- Correction des type hints `Dict[str, any]` → `Dict[str, Any]`